### PR TITLE
fix make cdc ld error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ build-failpoint: check_failpoint_ctl
 	$(FAILPOINT_DISABLE)
 
 cdc:
-	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc ./cmd/cdc/main.go
+	$(GOBUILD) -ldflags '$(LDFLAGS)' --ldflags '-extldflags="-Wl,--allow-multiple-definition"' -o bin/cdc ./cmd/cdc/main.go
 
 kafka_consumer:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc_kafka_consumer ./cmd/kafka-consumer/main.go


### PR DESCRIPTION
fix compile error when `make cdc`:

```
/usr/bin/ld: /home/ubuntu/go/pkg/mod/github.com/bytecodealliance/wasmtime-go@v1.0.0/build/linux-x86_64/libwasmtime.a(zstd_compress_sequences.o): in function `ZSTD_selectEncodingType':
zstd_compress_sequences.c:(.text.ZSTD_selectEncodingType+0x0): multiple definition of `ZSTD_selectEncodingType'; /tmp/go-link-3408648401/000079.o:/_/github.com/DataDog/zstd@v1.4.6-0.20210211175136-c6db21d202f4/zstd_compress_sequences.c:145: first defined here
/usr/bin/ld: /home/ubuntu/go/pkg/mod/github.com/bytecodealliance/wasmtime-go@v1.0.0/build/linux-x86_64/libwasmtime.a(zstd_compress_sequences.o): in function `ZSTD_buildCTable':
zstd_compress_sequences.c:(.text.ZSTD_buildCTable+0x0): multiple definition of `ZSTD_buildCTable'; /tmp/go-link-3408648401/000079.o:/_/github.com/DataDog/zstd@v1.4.6-0.20210211175136-c6db21d202f4/zstd_compress_sequences.c:226: first defined here
/usr/bin/ld: /home/ubuntu/go/pkg/mod/github.com/bytecodealliance/wasmtime-go@v1.0.0/build/linux-x86_64/libwasmtime.a(zstd_compress_sequences.o): in function `ZSTD_encodeSequences':
zstd_compress_sequences.c:(.text.ZSTD_encodeSequences+0x0): multiple definition of `ZSTD_encodeSequences'; /tmp/go-link-3408648401/000079.o:/_/github.com/DataDog/zstd@v1.4.6-0.20210211175136-c6db21d202f4/zstd_compress_sequences.c:398: first defined here
collect2: error: ld returned 1 exit status
```

The solution is in this answer:

https://stackoverflow.com/questions/56318343/golang-multiple-definition-of-cgo-ported-package